### PR TITLE
Fix Internet Explorer bug

### DIFF
--- a/src/css/public/gdpr-public.scss
+++ b/src/css/public/gdpr-public.scss
@@ -110,10 +110,11 @@
 				font-weight: normal;
 			}
 			.gdpr-content {
-				flex: 1;
+				width: 100%;
 				padding: 0 0 20px 0;
 				text-align: center;
 				@include breakpoint( xxlarge ) {
+					flex: 1;
 					padding: 0 100px 0 0;
 					text-align: left;
 				}


### PR DESCRIPTION
On viewports smaller than `xxlarge` `.gdpr-content` will overflow it's parent container.
See:

![gdpr](https://user-images.githubusercontent.com/8144115/40619556-cefc67cc-6295-11e8-9d21-9f7cd08c5293.png)

This PR fixes this. See:

![gdpr-after](https://user-images.githubusercontent.com/8144115/40619595-f9376492-6295-11e8-81e1-c805b48e8cd3.png)

