### PR TITLE
Remove H3 tags to improve SEO perf

### DIFF
--- a/public/partials/confirmation-screens.php
+++ b/public/partials/confirmation-screens.php
@@ -47,7 +47,7 @@ if ( isset( $_GET['notify'] ) && absint( $_GET['notify'] ) ) : // WPCS: Input va
 	<div class="gdpr-wrapper">
 		<header>
 			<div class="gdpr-box-title">
-				<h3><?php echo esc_attr( $title ); ?></h3>
+				<p><?php echo esc_attr( $title ); ?></p>
 				<span class="gdpr-close"></span>
 			</div>
 		</header>


### PR DESCRIPTION
Replacing H3 with P tags to optimize SEO