### PR TITLE
Added an option to show consent bar to EU visitors only

### DIFF
--- a/admin/class-gdpr-admin.php
+++ b/admin/class-gdpr-admin.php
@@ -548,6 +548,7 @@ class GDPR_Admin {
 					add_option( 'gdpr_enable_privacy_bar', true );
 					add_option( 'gdpr_display_cookie_categories_in_bar', false );
 					add_option( 'gdpr_hide_from_bots', true );
+					add_option( 'gdpr_show_eu_only', true );
 					add_option( 'gdpr_reconsent_template', 'modal' );
 				}
 			}

--- a/admin/class-gdpr-admin.php
+++ b/admin/class-gdpr-admin.php
@@ -200,6 +200,7 @@ class GDPR_Admin {
 			'gdpr_enable_privacy_bar'                  => 'boolval',
 			'gdpr_display_cookie_categories_in_bar'    => 'boolval',
 			'gdpr_hide_from_bots'                      => 'boolval',
+			'gdpr_show_eu_only'                        => 'boolval',
 			'gdpr_reconsent_template'                  => 'sanitize_text_field',
 		);
 		foreach ( $settings as $option_name => $sanitize_callback ) {

--- a/admin/partials/settings.php
+++ b/admin/partials/settings.php
@@ -9,101 +9,114 @@
 
 		<table class="form-table">
 			<tbody>
-				<tr>
-					<th scope="row">
-						<label for="gdpr_email_limit"><?php esc_html_e( 'Outgoing email limit', 'gdpr' ); ?>:</label>
-						<span class="screen-reader-text"><?php esc_attr_e( 'This is the hourly outgoing email limit set by your server.', 'gdpr' ); ?></span>
-						<span data-gdprtooltip="<?php esc_attr_e( 'This is the hourly outgoing email limit set by your server.', 'gdpr' ); ?>">
+			<tr>
+				<th scope="row">
+					<label for="gdpr_email_limit"><?php esc_html_e( 'Outgoing email limit', 'gdpr' ); ?>:</label>
+					<span class="screen-reader-text"><?php esc_attr_e( 'This is the hourly outgoing email limit set by your server.', 'gdpr' ); ?></span>
+					<span data-gdprtooltip="<?php esc_attr_e( 'This is the hourly outgoing email limit set by your server.', 'gdpr' ); ?>">
 							<span class="dashicons dashicons-info"></span>
 						</span>
-					</th>
-					<td>
-						<?php $limit = get_option( 'gdpr_email_limit', 100 ); ?>
-						<input type="number" name="gdpr_email_limit" id="gdpr_email_limit" value="<?php echo esc_attr( $limit ); ?>">
-						<span class="description"><?php esc_html_e( 'Emails/hour', 'gdpr' ); ?></span>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">
-						<label for="gdpr_deletion_needs_review"><?php esc_html_e( 'User deletion', 'gdpr' ); ?>:</label>
-						<span class="screen-reader-text"><?php esc_attr_e( 'Useful if you need to remove the user from third-party services.', 'gdpr' ); ?></span>
-						<span data-gdprtooltip="<?php esc_attr_e( 'Useful if you need to remove the user from third-party services.', 'gdpr' ); ?>">
+				</th>
+				<td>
+					<?php $limit = get_option( 'gdpr_email_limit', 100 ); ?>
+					<input type="number" name="gdpr_email_limit" id="gdpr_email_limit" value="<?php echo esc_attr( $limit ); ?>">
+					<span class="description"><?php esc_html_e( 'Emails/hour', 'gdpr' ); ?></span>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="gdpr_deletion_needs_review"><?php esc_html_e( 'User deletion', 'gdpr' ); ?>:</label>
+					<span class="screen-reader-text"><?php esc_attr_e( 'Useful if you need to remove the user from third-party services.', 'gdpr' ); ?></span>
+					<span data-gdprtooltip="<?php esc_attr_e( 'Useful if you need to remove the user from third-party services.', 'gdpr' ); ?>">
 							<span class="dashicons dashicons-info"></span>
 						</span>
-					</th>
-					<td>
-						<?php $needs_review = get_option( 'gdpr_deletion_needs_review', true ); ?>
-						<input type="checkbox" name="gdpr_deletion_needs_review" id="gdpr_deletion_needs_review" value="1"  <?php checked( $needs_review, true ); ?>><span class="description"><label for="gdpr_deletion_needs_review"><?php esc_html_e( 'Send all deletion requests to the review table.', 'gdpr' ); ?></label></span>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">
-						<label for="gdpr_refresh_after_preferences_update"><?php esc_html_e( 'Refresh page after updating preferences', 'gdpr' ); ?>:</label>
-					</th>
-					<td>
-						<?php $refresh_page = get_option( 'gdpr_refresh_after_preferences_update', false ); ?>
-						<input type="checkbox" name="gdpr_refresh_after_preferences_update" id="gdpr_refresh_after_preferences_update" value="1"  <?php checked( $refresh_page, true ); ?>>
-						<span class="description"><?php esc_html_e( 'Useful for landing pages or to track a visit with Google Analytics.', 'gdpr' ); ?></span>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">
-						<label for="gdpr_disable_css"><?php esc_html_e( 'Disable CSS', 'gdpr' ); ?>:</label>
-					</th>
-					<td>
-						<?php $disable_css = get_option( 'gdpr_disable_css', false ); ?>
-						<input type="checkbox" name="gdpr_disable_css" id="gdpr_disable_css" value="1"  <?php checked( $disable_css, true ); ?>><label for="gdpr_disable_css"><span class="description"><?php esc_html_e( 'Make sure you know what you are doing before checking this.', 'gdpr' ); ?></span></label>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">
-						<label for="gdpr_enable_telemetry_tracker"><?php esc_html_e( 'Enable the Telemetry Tracker', 'gdpr' ); ?>:</label>
-						<span class="screen-reader-text"><?php esc_attr_e( 'This tracks data that is being sent to outside servers.', 'gdpr' ); ?></span>
-						<span data-gdprtooltip="<?php esc_attr_e( 'This tracks data that is being sent to outside servers.', 'gdpr' ); ?>">
+				</th>
+				<td>
+					<?php $needs_review = get_option( 'gdpr_deletion_needs_review', true ); ?>
+					<input type="checkbox" name="gdpr_deletion_needs_review" id="gdpr_deletion_needs_review" value="1"  <?php checked( $needs_review, true ); ?>><span class="description"><label for="gdpr_deletion_needs_review"><?php esc_html_e( 'Send all deletion requests to the review table.', 'gdpr' ); ?></label></span>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="gdpr_refresh_after_preferences_update"><?php esc_html_e( 'Refresh page after updating preferences', 'gdpr' ); ?>:</label>
+				</th>
+				<td>
+					<?php $refresh_page = get_option( 'gdpr_refresh_after_preferences_update', false ); ?>
+					<input type="checkbox" name="gdpr_refresh_after_preferences_update" id="gdpr_refresh_after_preferences_update" value="1"  <?php checked( $refresh_page, true ); ?>>
+					<span class="description"><?php esc_html_e( 'Useful for landing pages or to track a visit with Google Analytics.', 'gdpr' ); ?></span>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="gdpr_disable_css"><?php esc_html_e( 'Disable CSS', 'gdpr' ); ?>:</label>
+				</th>
+				<td>
+					<?php $disable_css = get_option( 'gdpr_disable_css', false ); ?>
+					<input type="checkbox" name="gdpr_disable_css" id="gdpr_disable_css" value="1"  <?php checked( $disable_css, true ); ?>><label for="gdpr_disable_css"><span class="description"><?php esc_html_e( 'Make sure you know what you are doing before checking this.', 'gdpr' ); ?></span></label>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="gdpr_enable_telemetry_tracker"><?php esc_html_e( 'Enable the Telemetry Tracker', 'gdpr' ); ?>:</label>
+					<span class="screen-reader-text"><?php esc_attr_e( 'This tracks data that is being sent to outside servers.', 'gdpr' ); ?></span>
+					<span data-gdprtooltip="<?php esc_attr_e( 'This tracks data that is being sent to outside servers.', 'gdpr' ); ?>">
 							<span class="dashicons dashicons-info"></span>
 						</span>
-					</th>
-					<td>
-						<input type="checkbox" name="gdpr_enable_telemetry_tracker" id="gdpr_enable_telemetry_tracker" value="1" disabled><label for="gdpr_enable_telemetry_tracker"><span class="description"><?php echo sprintf( esc_html( 'The telemetry component has been discontinued. If you liked that feature and wants to use it, I recommend that you install this plugin: %s', 'gdpr' ), '<a href="https://wordpress.org/plugins/snitch/" target="_blank">Snitch</a>' ); ?></span></label>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">
-						<label for="gdpr_hide_from_bots"><?php esc_html_e( 'Hide plugin content from bots', 'gdpr' ); ?>:</label>
-						<span class="screen-reader-text"><?php esc_attr_e( 'We detect if the user agent is a bot like Googlebot and hide our added content from it. Displaying this content might be harmful for SEO.', 'gdpr' ); ?></span>
-						<span data-gdprtooltip="<?php esc_attr_e( 'We detect if the user agent is a bot like Googlebot and hide our added content from it. Displaying this content might be harmful for SEO.', 'gdpr' ); ?>">
+				</th>
+				<td>
+					<input type="checkbox" name="gdpr_enable_telemetry_tracker" id="gdpr_enable_telemetry_tracker" value="1" disabled><label for="gdpr_enable_telemetry_tracker"><span class="description"><?php echo sprintf( esc_html( 'The telemetry component has been discontinued. If you liked that feature and wants to use it, I recommend that you install this plugin: %s', 'gdpr' ), '<a href="https://wordpress.org/plugins/snitch/" target="_blank">Snitch</a>' ); ?></span></label>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="gdpr_hide_from_bots"><?php esc_html_e( 'Hide plugin content from bots', 'gdpr' ); ?>:</label>
+					<span class="screen-reader-text"><?php esc_attr_e( 'We detect if the user agent is a bot like Googlebot and hide our added content from it. Displaying this content might be harmful for SEO.', 'gdpr' ); ?></span>
+					<span data-gdprtooltip="<?php esc_attr_e( 'We detect if the user agent is a bot like Googlebot and hide our added content from it. Displaying this content might be harmful for SEO.', 'gdpr' ); ?>">
 							<span class="dashicons dashicons-info"></span>
 						</span>
-					</th>
-					<td>
-						<?php $hide_from_bots = get_option( 'gdpr_hide_from_bots', true ); ?>
-						<input type="checkbox" name="gdpr_hide_from_bots" id="gdpr_hide_from_bots" value="1"  <?php checked( $hide_from_bots, true ); ?>>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">
-						<label for="gdpr_reconsent_template"><?php esc_html_e( 'Template to use when asking for re-consent', 'gdpr' ); ?>:</label>
-						<span class="screen-reader-text"><?php esc_attr_e( 'Users can choose between a bar similar to the privacy bar that does not prevent navigation and a modal that displays the new policy content and prevents navigation until accepted.', 'gdpr' ); ?></span>
-						<span data-gdprtooltip="<?php esc_attr_e( 'Users can choose between a bar similar to the privacy bar that does not prevent navigation and a modal that displays the new policy content and prevents navigation until accepted.', 'gdpr' ); ?>">
+				</th>
+				<td>
+					<?php $hide_from_bots = get_option( 'gdpr_hide_from_bots', true ); ?>
+					<input type="checkbox" name="gdpr_hide_from_bots" id="gdpr_hide_from_bots" value="1"  <?php checked( $hide_from_bots, true ); ?>>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="gdpr_show_eu_only"><?php esc_html_e( 'Show Consent Bar to EU Visitors only', 'gdpr' ); ?>:</label>
+					<span class="screen-reader-text"><?php esc_attr_e( 'We detect if the user visits from an EU IP address and hide the consent bar for non-eu users', 'gdpr' ); ?></span>
+					<span data-gdprtooltip="<?php esc_attr_e( 'We detect if the user visits from an EU IP address and hide the consent bar for non-eu users', 'gdpr' ); ?>">
 							<span class="dashicons dashicons-info"></span>
 						</span>
-					</th>
-					<td>
-						<?php $reconsent_template = get_option( 'gdpr_reconsent_template', 'modal' ); ?>
-						<select name="gdpr_reconsent_template" id="gdpr_reconsent_template">
-							<option value="bar" <?php selected( 'bar', $reconsent_template ) ?>><?php esc_html_e( 'Bar', 'gdpr' ); ?></option>
-							<option value="modal" <?php selected( 'modal', $reconsent_template ) ?>><?php esc_html_e( 'Modal', 'gdpr' ); ?></option>
-						</select>
-					</td>
-				</tr>
+				</th>
+				<td>
+					<?php $show_eu_only = get_option( 'gdpr_show_eu_only', true ); ?>
+					<input type="checkbox" name="gdpr_show_eu_only" id="gdpr_show_eu_only" value="1"  <?php checked( $show_eu_only, true ); ?>>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="gdpr_reconsent_template"><?php esc_html_e( 'Template to use when asking for re-consent', 'gdpr' ); ?>:</label>
+					<span class="screen-reader-text"><?php esc_attr_e( 'Users can choose between a bar similar to the privacy bar that does not prevent navigation and a modal that displays the new policy content and prevents navigation until accepted.', 'gdpr' ); ?></span>
+					<span data-gdprtooltip="<?php esc_attr_e( 'Users can choose between a bar similar to the privacy bar that does not prevent navigation and a modal that displays the new policy content and prevents navigation until accepted.', 'gdpr' ); ?>">
+							<span class="dashicons dashicons-info"></span>
+						</span>
+				</th>
+				<td>
+					<?php $reconsent_template = get_option( 'gdpr_reconsent_template', 'modal' ); ?>
+					<select name="gdpr_reconsent_template" id="gdpr_reconsent_template">
+						<option value="bar" <?php selected( 'bar', $reconsent_template ) ?>><?php esc_html_e( 'Bar', 'gdpr' ); ?></option>
+						<option value="modal" <?php selected( 'modal', $reconsent_template ) ?>><?php esc_html_e( 'Modal', 'gdpr' ); ?></option>
+					</select>
+				</td>
+			</tr>
 			</tbody>
 		</table>
 		<hr>
 		<h2 class="title"><?php esc_html_e( 'Privacy Center', 'gdpr' ); ?></h2>
 		<p>
 			<?php esc_html_e( 'This section handles the privacy bar and some of the privacy preferences window.', 'gdpr' ); ?><br>
-		<table class="form-table">
-			<tbody>
+			<table class="form-table">
+				<tbody>
 				<tr>
 					<th scope="row">
 						<label for="gdpr_enable_privacy_bar"><?php esc_html_e( 'Enable the Privacy Bar', 'gdpr' ); ?>:</label>
@@ -146,52 +159,52 @@
 					<td>
 						<?php $privacy_excerpt = get_option( 'gdpr_cookie_privacy_excerpt', '' ); ?>
 						<textarea name="gdpr_cookie_privacy_excerpt" id="gdpr_cookie_privacy_excerpt" cols="80" rows="6"><?php echo esc_html( $privacy_excerpt ); ?></textarea>
-						<p class="description"><?php esc_html_e( 'This will appear in the consent section of the privacy preference window.', 'gdpr' ); ?></p>
-					</td>
-				</tr>
-			</tbody>
+		<p class="description"><?php esc_html_e( 'This will appear in the consent section of the privacy preference window.', 'gdpr' ); ?></p>
+		</td>
+		</tr>
+		</tbody>
 		</table>
 		<hr>
 		<h2 class="title"><?php esc_html_e( 'Request Forms reCAPTCHA', 'gdpr' ); ?></h2>
 		<p><?php esc_html_e( 'To prevent spam attacks, you have the option to enable reCAPTCHA. Configure your keys below to make it work with our request forms.', 'gdpr' ); ?></p>
 		<p>
 			<?php
-			echo sprintf(
+				echo sprintf(
 				/* translators: External link with instructions on how to proceed. */
-				esc_html__( 'You can find the necessary information %s.', 'gdpr' ),
-				'<a href="https://www.google.com/recaptcha/admin" target="_blank">' . esc_html__( 'here', 'gdpr' ) . '</a>'
-			)
+					esc_html__( 'You can find the necessary information %s.', 'gdpr' ),
+					'<a href="https://www.google.com/recaptcha/admin" target="_blank">' . esc_html__( 'here', 'gdpr' ) . '</a>'
+				)
 			?>
-			</p>
+		</p>
 		<table class="form-table">
 			<tbody>
-				<tr>
-					<th scope="row">
-						<label for="gdpr_use_recaptcha"><?php esc_html_e( 'Enable reCAPTCHA', 'gdpr' ); ?>:</label>
-					</th>
-					<td>
-						<?php $use_recaptcha = get_option( 'gdpr_use_recaptcha', false ); ?>
-						<input type="checkbox" name="<?php echo esc_attr( 'gdpr_use_recaptcha' ); ?>" id="gdpr_use_recaptcha" value="1"  <?php checked( $use_recaptcha, true ); ?>>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">
-						<label for="gdpr_recaptcha_site_key"><?php esc_html_e( 'Site Key', 'gdpr' ); ?>:</label>
-					</th>
-					<td>
-						<?php $site_key = get_option( 'gdpr_recaptcha_site_key', '' ); ?>
-						<input type="text" name="gdpr_recaptcha_site_key" value="<?php echo esc_attr( $site_key ); ?>" placeholder="">
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">
-						<label for="gdpr_recaptcha_secret_key"><?php esc_html_e( 'Secret Key', 'gdpr' ); ?>:</label>
-					</th>
-					<td>
-						<?php $secret_key = get_option( 'gdpr_recaptcha_secret_key', '' ); ?>
-						<input type="password" name="gdpr_recaptcha_secret_key" value="<?php echo esc_attr( $secret_key ); ?>" placeholder="">
-					</td>
-				</tr>
+			<tr>
+				<th scope="row">
+					<label for="gdpr_use_recaptcha"><?php esc_html_e( 'Enable reCAPTCHA', 'gdpr' ); ?>:</label>
+				</th>
+				<td>
+					<?php $use_recaptcha = get_option( 'gdpr_use_recaptcha', false ); ?>
+					<input type="checkbox" name="<?php echo esc_attr( 'gdpr_use_recaptcha' ); ?>" id="gdpr_use_recaptcha" value="1"  <?php checked( $use_recaptcha, true ); ?>>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="gdpr_recaptcha_site_key"><?php esc_html_e( 'Site Key', 'gdpr' ); ?>:</label>
+				</th>
+				<td>
+					<?php $site_key = get_option( 'gdpr_recaptcha_site_key', '' ); ?>
+					<input type="text" name="gdpr_recaptcha_site_key" value="<?php echo esc_attr( $site_key ); ?>" placeholder="">
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="gdpr_recaptcha_secret_key"><?php esc_html_e( 'Secret Key', 'gdpr' ); ?>:</label>
+				</th>
+				<td>
+					<?php $secret_key = get_option( 'gdpr_recaptcha_secret_key', '' ); ?>
+					<input type="password" name="gdpr_recaptcha_secret_key" value="<?php echo esc_attr( $secret_key ); ?>" placeholder="">
+				</td>
+			</tr>
 			</tbody>
 		</table>
 		<?php if ( class_exists( 'WooCommerce' ) ) : ?>
@@ -199,24 +212,24 @@
 			<h2 class="title"><?php esc_html_e( 'WooCommerce', 'gdpr' ); ?></h2>
 			<table class="form-table">
 				<tbody>
-					<tr>
-						<th scope="row">
-							<label for="gdpr_add_consent_checkboxes_registration"><?php esc_html_e( 'Add consent checkboxes to the registration page', 'gdpr' ); ?>:</label>
-						</th>
-						<td>
-							<?php $add_checkboxes_to_registration = get_option( 'gdpr_add_consent_checkboxes_registration', false ); ?>
-							<input type="checkbox" name="<?php echo esc_attr( 'gdpr_add_consent_checkboxes_registration' ); ?>" id="gdpr_add_consent_checkboxes_registration" value="1"  <?php checked( $add_checkboxes_to_registration, true ); ?>>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row">
-							<label for="gdpr_add_consent_checkboxes_checkout"><?php esc_html_e( 'Add consent checkboxes to the checkout registration form', 'gdpr' ); ?>:</label>
-						</th>
-						<td>
-							<?php $add_checkboxes_to_checkout = get_option( 'gdpr_add_consent_checkboxes_checkout', false ); ?>
-							<input type="checkbox" name="<?php echo esc_attr( 'gdpr_add_consent_checkboxes_checkout' ); ?>" id="gdpr_add_consent_checkboxes_checkout" value="1"  <?php checked( $add_checkboxes_to_checkout, true ); ?>>
-						</td>
-					</tr>
+				<tr>
+					<th scope="row">
+						<label for="gdpr_add_consent_checkboxes_registration"><?php esc_html_e( 'Add consent checkboxes to the registration page', 'gdpr' ); ?>:</label>
+					</th>
+					<td>
+						<?php $add_checkboxes_to_registration = get_option( 'gdpr_add_consent_checkboxes_registration', false ); ?>
+						<input type="checkbox" name="<?php echo esc_attr( 'gdpr_add_consent_checkboxes_registration' ); ?>" id="gdpr_add_consent_checkboxes_registration" value="1"  <?php checked( $add_checkboxes_to_registration, true ); ?>>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">
+						<label for="gdpr_add_consent_checkboxes_checkout"><?php esc_html_e( 'Add consent checkboxes to the checkout registration form', 'gdpr' ); ?>:</label>
+					</th>
+					<td>
+						<?php $add_checkboxes_to_checkout = get_option( 'gdpr_add_consent_checkboxes_checkout', false ); ?>
+						<input type="checkbox" name="<?php echo esc_attr( 'gdpr_add_consent_checkboxes_checkout' ); ?>" id="gdpr_add_consent_checkboxes_checkout" value="1"  <?php checked( $add_checkboxes_to_checkout, true ); ?>>
+					</td>
+				</tr>
 				</tbody>
 			</table>
 		<?php endif ?>
@@ -294,66 +307,66 @@
 								<td><textarea name="gdpr_cookie_popup_content[<?php echo esc_attr( $cat_id ); ?>][how_we_use]" id="tab-how-we-use-<?php echo esc_attr( $cat_id ); ?>" cols="53" rows="3"><?php echo esc_html( $registered_cookies[ $cat_id ]['how_we_use'] ); ?></textarea></td>
 							</tr>
 							<tr>
-				<th>
-					<label for="hosts-<?php echo esc_attr( $cat_id ); ?>">
-						<?php esc_html_e( 'Third party domain', 'gdpr' ); ?>:
-						<span class="screen-reader-text"><?php esc_attr_e( 'E.g. facebook.com', 'gdpr' ); ?></span>
-						<span data-gdprtooltip="<?php esc_attr_e( 'E.g. facebook.com', 'gdpr' ); ?>">
+								<th>
+									<label for="hosts-<?php echo esc_attr( $cat_id ); ?>">
+										<?php esc_html_e( 'Third party domain', 'gdpr' ); ?>:
+										<span class="screen-reader-text"><?php esc_attr_e( 'E.g. facebook.com', 'gdpr' ); ?></span>
+										<span data-gdprtooltip="<?php esc_attr_e( 'E.g. facebook.com', 'gdpr' ); ?>">
 							<span class="dashicons dashicons-info"></span>
 						</span>
-					</label>
-				</th>
-				<td>
-					<input type="text" id="hosts-<?php echo esc_attr( $cat_id ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'domain.com', 'gdpr' ); ?>" />
-					<button class="button button-primary add-host" data-tabid="<?php echo esc_attr( $cat_id ); ?>"><?php esc_html_e( 'Add', 'gdpr' ); ?></button>
-					<br>
-					<span class="description"><?php esc_html_e( 'Cookies that are set by a third party, like facebook.com.', 'gdpr' ); ?></span>
-				</td>
-				</tr>
+									</label>
+								</th>
+								<td>
+									<input type="text" id="hosts-<?php echo esc_attr( $cat_id ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'domain.com', 'gdpr' ); ?>" />
+									<button class="button button-primary add-host" data-tabid="<?php echo esc_attr( $cat_id ); ?>"><?php esc_html_e( 'Add', 'gdpr' ); ?></button>
+									<br>
+									<span class="description"><?php esc_html_e( 'Cookies that are set by a third party, like facebook.com.', 'gdpr' ); ?></span>
+								</td>
+							</tr>
 						</table>
 						<div class="tab-hosts" data-tabid="<?php echo esc_attr( $cat_id ); ?>">
-				<?php if ( isset( $cookie_cat['hosts'] ) && $cookie_cat['hosts'] ) : ?>
-				<?php foreach ( $cookie_cat['hosts'] as $domain_id => $domain ) : ?>
-					<div class="postbox">
-					<h2 class="hndle"><?php echo esc_attr( $domain_id ); ?><button class="notice-dismiss" type="button" aria-label="<?php esc_attr_e( 'Remove this domain.', 'gdpr' ); ?>"></button></h2>
-					<div class="inside">
-						<table class="form-table">
-						<tr>
-							<th>
-								<label for="hosts-cookies-used-<?php echo esc_attr( $domain_id ); ?>">
-									<?php esc_html_e( 'Cookies used', 'gdpr' ); ?>:
-									<span class="screen-reader-text"><?php esc_attr_e( 'A comma separated list of cookies that your site is using from this third-party provider.', 'gdpr' ); ?></span>
-									<span data-gdprtooltip="<?php esc_attr_e( 'A comma separated list of cookies that your site is using from this third-party provider.', 'gdpr' ); ?>">
+							<?php if ( isset( $cookie_cat['hosts'] ) && $cookie_cat['hosts'] ) : ?>
+								<?php foreach ( $cookie_cat['hosts'] as $domain_id => $domain ) : ?>
+									<div class="postbox">
+										<h2 class="hndle"><?php echo esc_attr( $domain_id ); ?><button class="notice-dismiss" type="button" aria-label="<?php esc_attr_e( 'Remove this domain.', 'gdpr' ); ?>"></button></h2>
+										<div class="inside">
+											<table class="form-table">
+												<tr>
+													<th>
+														<label for="hosts-cookies-used-<?php echo esc_attr( $domain_id ); ?>">
+															<?php esc_html_e( 'Cookies used', 'gdpr' ); ?>:
+															<span class="screen-reader-text"><?php esc_attr_e( 'A comma separated list of cookies that your site is using from this third-party provider.', 'gdpr' ); ?></span>
+															<span data-gdprtooltip="<?php esc_attr_e( 'A comma separated list of cookies that your site is using from this third-party provider.', 'gdpr' ); ?>">
 										<span class="dashicons dashicons-info"></span>
 									</span>
-								</label>
-							</th>
-							<td>
-							<textarea cols="53" rows="3" name="gdpr_cookie_popup_content[<?php echo esc_attr( $cat_id ); ?>][hosts][<?php echo esc_attr( $domain_id ); ?>][cookies_used]" id="hosts-cookies-used-<?php echo esc_attr( $domain_id ); ?>"><?php echo esc_attr( $domain['cookies_used'] ); ?></textarea>
-							</td>
-						</tr>
-						<tr>
-							<th>
-								<label for="hosts-cookies-optout-<?php echo esc_attr( $domain_id ); ?>">
-									<?php esc_html_e( 'Opt Out Link', 'gdpr' ); ?>:
-									<span class="screen-reader-text"><?php esc_attr_e( 'Add a link with the third-party instructions on how to opt out of their cookies.', 'gdpr' ); ?></span>
-									<span data-gdprtooltip="<?php esc_attr_e( 'Add a link with the third-party instructions on how to opt out of their cookies.', 'gdpr' ); ?>">
+														</label>
+													</th>
+													<td>
+														<textarea cols="53" rows="3" name="gdpr_cookie_popup_content[<?php echo esc_attr( $cat_id ); ?>][hosts][<?php echo esc_attr( $domain_id ); ?>][cookies_used]" id="hosts-cookies-used-<?php echo esc_attr( $domain_id ); ?>"><?php echo esc_attr( $domain['cookies_used'] ); ?></textarea>
+													</td>
+												</tr>
+												<tr>
+													<th>
+														<label for="hosts-cookies-optout-<?php echo esc_attr( $domain_id ); ?>">
+															<?php esc_html_e( 'Opt Out Link', 'gdpr' ); ?>:
+															<span class="screen-reader-text"><?php esc_attr_e( 'Add a link with the third-party instructions on how to opt out of their cookies.', 'gdpr' ); ?></span>
+															<span data-gdprtooltip="<?php esc_attr_e( 'Add a link with the third-party instructions on how to opt out of their cookies.', 'gdpr' ); ?>">
 										<span class="dashicons dashicons-info"></span>
 									</span>
-								</label>
-							</th>
-							<td>
-							<input type="text" name="gdpr_cookie_popup_content[<?php echo esc_attr( $cat_id ); ?>][hosts][<?php echo esc_attr( $domain_id ); ?>][optout]" value="<?php echo esc_attr( $domain['optout'] ); ?>" id="hosts-cookies-optout-<?php echo esc_attr( $domain_id ); ?>" class="regular-text" />
-							<br>
-							<span class="description"><?php esc_html_e( 'Url with instructions on how to opt out.', 'gdpr' ); ?></span>
-							</td>
-						</tr>
-						</table>
-					</div>
-					</div>
-				<?php endforeach; ?>
-				<?php endif; ?>
-			</div>
+														</label>
+													</th>
+													<td>
+														<input type="text" name="gdpr_cookie_popup_content[<?php echo esc_attr( $cat_id ); ?>][hosts][<?php echo esc_attr( $domain_id ); ?>][optout]" value="<?php echo esc_attr( $domain['optout'] ); ?>" id="hosts-cookies-optout-<?php echo esc_attr( $domain_id ); ?>" class="regular-text" />
+														<br>
+														<span class="description"><?php esc_html_e( 'Url with instructions on how to opt out.', 'gdpr' ); ?></span>
+													</td>
+												</tr>
+											</table>
+										</div>
+									</div>
+								<?php endforeach; ?>
+							<?php endif; ?>
+						</div>
 					</div><!-- .inside -->
 				</div><!-- .postbox -->
 			<?php endforeach; ?>
@@ -421,10 +434,10 @@
 			<?php endif ?>
 		</div>
 		<?php
-		do_action( 'gdpr_extra_settings' );
-		submit_button();
+			do_action( 'gdpr_extra_settings' );
+			submit_button();
 		?>
 	</form>
 
-<!-- #poststuff -->
+	<!-- #poststuff -->
 </div>

--- a/public/class-gdpr-public.php
+++ b/public/class-gdpr-public.php
@@ -234,7 +234,19 @@
 		 */
 		public function get_visitor_ip () {
 
-			return $_SERVER[ "HTTP_CF_CONNECTING_IP" ] ?? $_SERVER[ "HTTP_X_REAL_IP" ] ?? $_SERVER[ "HTTP_X_FORWARDED_FOR" ] ?? $_SERVER[ "HTTP_CLIENT_IP" ] ?? $_SERVER[ "REMOTE_ADDR" ] ?? null;
+			if ( ! empty( $_SERVER[ 'HTTP_CF_CONNECTING_IP' ] ) ) {
+				return $_SERVER[ 'HTTP_CF_CONNECTING_IP' ];
+			} else if ( ! empty( $_SERVER[ 'HTTP_X_REAL_IP' ] ) ) {
+				return $_SERVER[ 'HTTP_X_REAL_IP' ];
+			} else if ( ! empty( $_SERVER[ 'HTTP_CLIENT_IP' ] ) ) {
+				return $_SERVER[ 'HTTP_CLIENT_IP' ];
+			} else if ( ! empty( $_SERVER[ 'HTTP_X_FORWARDED_FOR' ] ) ) {
+				return $_SERVER[ 'HTTP_X_FORWARDED_FOR' ];
+			} else if ( ! empty( $_SERVER[ 'REMOTE_ADDR' ] ) ) {
+				return $_SERVER[ 'REMOTE_ADDR' ];
+			}
+
+			return null;
 		}
 
 		/**

--- a/public/class-gdpr-public.php
+++ b/public/class-gdpr-public.php
@@ -1,414 +1,478 @@
 <?php
 
-/**
- * The public-facing functionality of the plugin.
- *
- * @link       https://trewknowledge.com
- * @since      1.0.0
- *
- * @package    GDPR
- * @subpackage public
- * @author     Fernando Claussen <fernandoclaussen@gmail.com>
- */
-
-require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-gdpr-templates.php';
-
-/**
- * The public-facing functionality of the plugin.
- *
- * Defines the plugin name and version.
- * Enqueue the admin-specific stylesheet and JavaScript.
- *
- * @package    GDPR
- * @subpackage public
- * @author     Fernando Claussen <fernandoclaussen@gmail.com>
- */
-class GDPR_Public {
-
 	/**
-	 * The ID of this plugin.
+	 * The public-facing functionality of the plugin.
 	 *
-	 * @since  1.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 * @access private
-	 * @var    string    $plugin_name    The ID of this plugin.
-	 */
-	private $plugin_name;
-
-	/**
-	 * The version of this plugin.
+	 * @link       https://trewknowledge.com
+	 * @since      1.0.0
 	 *
-	 * @since  1.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 * @access private
-	 * @var    string    $version    The current version of this plugin.
+	 * @package    GDPR
+	 * @subpackage public
+	 * @author     Fernando Claussen <fernandoclaussen@gmail.com>
 	 */
-	private $version;
+
+	require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-gdpr-templates.php';
 
 	/**
-	 * Allowed HTML for wp_kses.
-	 * @since  1.1.0
-	 * @access private
-	 * @var    array   $allowed_html   The allowed HTML for wp_kses.
-	 */
-	private $allowed_html;
-
-	/**
-	 * Initialize the class and set its properties.
+	 * The public-facing functionality of the plugin.
 	 *
-	 * @since  1.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 * @param  string    $plugin_name    The name of the plugin.
-	 * @param  string    $version        The version of this plugin.
+	 * Defines the plugin name and version.
+	 * Enqueue the admin-specific stylesheet and JavaScript.
+	 *
+	 * @package    GDPR
+	 * @subpackage public
+	 * @author     Fernando Claussen <fernandoclaussen@gmail.com>
 	 */
-	public function __construct( $plugin_name, $version ) {
-		$this->plugin_name  = $plugin_name;
-		$this->version      = $version;
-		$this->allowed_html = array(
-			'a' => array(
-				'href'   => true,
-				'title'  => true,
-				'target' => true,
-			),
-		);
-	}
+	class GDPR_Public {
 
-	/**
-	 * Checks if recaptcha is being used and add the code.
-	 * Should be called from the request forms.
-	 * @since  1.4.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 */
-	public static function add_recaptcha() {
-		$use_recaptcha = get_option( 'gdpr_use_recaptcha', false );
-		if ( $use_recaptcha ) {
-			$site_key   = get_option( 'gdpr_recaptcha_site_key', '' );
-			$secret_key = get_option( 'gdpr_recaptcha_secret_key', '' );
+		/**
+		 * The ID of this plugin.
+		 *
+		 * @since  1.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 * @access private
+		 * @var    string $plugin_name The ID of this plugin.
+		 */
+		private $plugin_name;
 
-			if ( $site_key && $secret_key ) {
-				echo '<div class="g-recaptcha" data-sitekey="' . esc_attr( $site_key ) . '"></div>';
+		/**
+		 * The version of this plugin.
+		 *
+		 * @since  1.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 * @access private
+		 * @var    string $version The current version of this plugin.
+		 */
+		private $version;
+
+		/**
+		 * Allowed HTML for wp_kses.
+		 *
+		 * @since  1.1.0
+		 * @access private
+		 * @var    array $allowed_html The allowed HTML for wp_kses.
+		 */
+		private $allowed_html;
+
+		/**
+		 * Initialize the class and set its properties.
+		 *
+		 * @since  1.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 *
+		 * @param  string $plugin_name The name of the plugin.
+		 * @param  string $version     The version of this plugin.
+		 */
+		public function __construct ( $plugin_name, $version ) {
+
+			$this->plugin_name  = $plugin_name;
+			$this->version      = $version;
+			$this->allowed_html = [
+				'a' => [
+					'href'   => true,
+					'title'  => true,
+					'target' => true,
+				],
+			];
+		}
+
+		/**
+		 * Checks if recaptcha is being used and add the code.
+		 * Should be called from the request forms.
+		 *
+		 * @since  1.4.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 */
+		public static function add_recaptcha () {
+
+			$use_recaptcha = get_option( 'gdpr_use_recaptcha', false );
+			if ( $use_recaptcha ) {
+				$site_key   = get_option( 'gdpr_recaptcha_site_key', '' );
+				$secret_key = get_option( 'gdpr_recaptcha_secret_key', '' );
+
+				if ( $site_key && $secret_key ) {
+					echo '<div class="g-recaptcha" data-sitekey="' . esc_attr( $site_key ) . '"></div>';
+				}
 			}
 		}
-	}
 
-	/**
-	 * Register the stylesheets for the public-facing side of the site.
-	 *
-	 * @since  1.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 */
-	public function enqueue_styles() {
-		$disable_css = get_option( 'gdpr_disable_css', false );
-		if ( ! $disable_css ) {
-			wp_enqueue_style( $this->plugin_name, plugin_dir_url( dirname( __FILE__ ) ) . 'assets/css/gdpr-public.css', array(), $this->version, 'all' );
-		}
-	}
+		/**
+		 * Register the stylesheets for the public-facing side of the site.
+		 *
+		 * @since  1.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 */
+		public function enqueue_styles () {
 
-	/**
-	 * Register the JavaScript for the public-facing side of the site.
-	 *
-	 * @since  1.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 */
-	public function enqueue_scripts() {
-		$use_recaptcha = get_option( 'gdpr_use_recaptcha', false );
-		if ( $use_recaptcha ) {
-			$site_key   = get_option( 'gdpr_recaptcha_site_key', '' );
-			$secret_key = get_option( 'gdpr_recaptcha_secret_key', '' );
-
-			if ( $site_key && $secret_key ) {
-				$lang = get_locale();
-				wp_enqueue_script( $this->plugin_name . '-recaptcha', 'https://www.google.com/recaptcha/api.js?hl=' . $lang );
+			$disable_css = get_option( 'gdpr_disable_css', false );
+			if ( ! $disable_css ) {
+				wp_enqueue_style( $this->plugin_name, plugin_dir_url( dirname( __FILE__ ) ) . 'assets/css/gdpr-public.css', [], $this->version, 'all' );
 			}
 		}
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( dirname( __FILE__ ) ) . 'assets/js/gdpr-public.js', array( 'jquery' ), $this->version, false );
-		wp_localize_script(
-			$this->plugin_name, 'GDPR', array(
-				'ajaxurl'           => admin_url( 'admin-ajax.php' ),
-				'logouturl'         => is_user_logged_in() ? esc_url( wp_logout_url( home_url() ) ) : '',
-				'i18n'              => array(
-					'aborting'              => esc_html__( 'Aborting', 'gdpr' ),
-					'logging_out'           => esc_html__( 'You are being logged out.', 'gdpr' ),
-					'continue'              => esc_html__( 'Continue', 'gdpr' ),
-					'cancel'                => esc_html__( 'Cancel', 'gdpr' ),
-					'ok'                    => esc_html__( 'OK', 'gdpr' ),
-					'close_account'         => esc_html__( 'Close your account?', 'gdpr' ),
-					'close_account_warning' => esc_html__( 'Your account will be closed and all data will be permanently deleted and cannot be recovered. Are you sure?', 'gdpr' ),
-					'are_you_sure'          => esc_html__( 'Are you sure?', 'gdpr' ),
-					'policy_disagree'       => esc_html__( 'By disagreeing you will no longer have access to our site and will be logged out.', 'gdpr' ),
-				),
-				'is_user_logged_in' => is_user_logged_in(),
-				'refresh'           => get_option( 'gdpr_refresh_after_preferences_update', true ),
-			)
-		);
-	}
 
-	/**
-	 * Prints the privacy bar for the end user to save the consent and cookie settings.
-	 * @since  1.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 */
-	public function privacy_bar() {
-		$privacy_bar_enabled        = get_option( 'gdpr_enable_privacy_bar', true );
-		$content                    = get_option( 'gdpr_cookie_banner_content', '' );
-		$registered_cookies         = get_option( 'gdpr_cookie_popup_content', array() );
-		$show_cookie_cat_checkboxes = get_option( 'gdpr_display_cookie_categories_in_bar', false );
-		$button_text                = apply_filters( 'gdpr_privacy_bar_button_text', esc_html__( 'I Agree', 'gdpr' ) );
-		$privacy_bar_enabled        = apply_filters( 'gdpr_privacy_bar_display', $privacy_bar_enabled );
-		$hide_from_bots             = get_option( 'gdpr_hide_from_bots', true );
+		/**
+		 * Register the JavaScript for the public-facing side of the site.
+		 *
+		 * @since  1.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 */
+		public function enqueue_scripts () {
 
-		if ( ! $privacy_bar_enabled || ( $hide_from_bots && $this->is_crawler() ) ) {
-			return;
-		}
+			$use_recaptcha = get_option( 'gdpr_use_recaptcha', false );
+			if ( $use_recaptcha ) {
+				$site_key   = get_option( 'gdpr_recaptcha_site_key', '' );
+				$secret_key = get_option( 'gdpr_recaptcha_secret_key', '' );
 
-		GDPR_Templates::get_template( 'privacy-bar.php', array(
-			'content' => $content,
-			'registered_cookies' => $registered_cookies,
-			'show_cookie_cat_checkboxes' => $show_cookie_cat_checkboxes,
-			'button_text' => $button_text,
-		) );
-	}
-
-	/**
-	 * The privacy preferences modal.
-	 * @since  1.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 */
-	public function privacy_preferences_modal() {
-		$cookie_privacy_excerpt = get_option( 'gdpr_cookie_privacy_excerpt', '' );
-		$consent_types          = get_option( 'gdpr_consent_types', array() );
-		$approved_cookies       = isset( $_COOKIE['gdpr']['allowed_cookies'] ) ? json_decode( wp_unslash( $_COOKIE['gdpr']['allowed_cookies'] ) ) : array(); // WPCS: Input var ok, sanitization ok..
-		$user_consents          = isset( $_COOKIE['gdpr']['consent_types'] ) ? json_decode( wp_unslash( $_COOKIE['gdpr']['consent_types'] ) ) : array(); // WPCS: Input var ok, sanitization ok.
-		$tabs                   = get_option( 'gdpr_cookie_popup_content', array() );
-		$hide_from_bots         = get_option( 'gdpr_hide_from_bots', true );
-
-		if ( $hide_from_bots && $this->is_crawler() ) {
-			return;
-		}
-
-		GDPR_Templates::get_template( 'privacy-preferences-modal.php', array(
-			'cookie_privacy_excerpt' => $cookie_privacy_excerpt,
-			'consent_types' => $consent_types,
-			'approved_cookies' => $approved_cookies,
-			'user_consents' => $user_consents,
-			'tabs' => $tabs,
-			'allowed_html' => $this->allowed_html,
-		) );
-	}
-
-	/**
-	 * The black overlay for the plugin modals.
-	 * @since  1.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 */
-	public function overlay() {
-		echo '<div class="gdpr gdpr-overlay"></div>';
-	}
-
-	/**
-	 * Prints the confirmation dialogs.
-	 * @since  1.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 */
-	public function confirmation_screens() {
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/partials/confirmation-screens.php';
-	}
-
-	/**
-	 * Update the user allowed cookies and types of consent.
-	 * If the user is logged in, we also save consent to user meta.
-	 * Ajax version of a previous function.
-	 * @since  2.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 */
-	public function update_privacy_preferences() {
-		if ( ! isset( $_POST['update-privacy-preferences-nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['update-privacy-preferences-nonce'] ), 'gdpr-update-privacy-preferences' ) ) { // WPCS: Input var ok.
-			wp_send_json_error(
-				array(
-					'title'   => esc_html__( 'Error!', 'gdpr' ),
-					'content' => esc_html__( 'We could not verify the security token. Please try again.', 'gdpr' ),
-				)
+				if ( $site_key && $secret_key ) {
+					$lang = get_locale();
+					wp_enqueue_script( $this->plugin_name . '-recaptcha', 'https://www.google.com/recaptcha/api.js?hl=' . $lang );
+				}
+			}
+			wp_enqueue_script( $this->plugin_name, plugin_dir_url( dirname( __FILE__ ) ) . 'assets/js/gdpr-public.js', [ 'jquery' ], $this->version, false );
+			wp_localize_script(
+				$this->plugin_name, 'GDPR', [
+					'ajaxurl'           => admin_url( 'admin-ajax.php' ),
+					'logouturl'         => is_user_logged_in() ? esc_url( wp_logout_url( home_url() ) ) : '',
+					'i18n'              => [
+						'aborting'              => esc_html__( 'Aborting', 'gdpr' ),
+						'logging_out'           => esc_html__( 'You are being logged out.', 'gdpr' ),
+						'continue'              => esc_html__( 'Continue', 'gdpr' ),
+						'cancel'                => esc_html__( 'Cancel', 'gdpr' ),
+						'ok'                    => esc_html__( 'OK', 'gdpr' ),
+						'close_account'         => esc_html__( 'Close your account?', 'gdpr' ),
+						'close_account_warning' => esc_html__( 'Your account will be closed and all data will be permanently deleted and cannot be recovered. Are you sure?', 'gdpr' ),
+						'are_you_sure'          => esc_html__( 'Are you sure?', 'gdpr' ),
+						'policy_disagree'       => esc_html__( 'By disagreeing you will no longer have access to our site and will be logged out.', 'gdpr' ),
+					],
+					'is_user_logged_in' => is_user_logged_in(),
+					'refresh'           => get_option( 'gdpr_refresh_after_preferences_update', true ),
+				]
 			);
 		}
-		$consents    = isset( $_POST['user_consents'] ) ? array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['user_consents'] ) ) : array(); // WPCS: Input var ok.
-		$cookies     = isset( $_POST['approved_cookies'] ) ? array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['approved_cookies'] ) ) : array(); // WPCS: Input var ok.
-		$all_cookies = isset( $_POST['all_cookies'] ) ? array_map( 'sanitize_text_field', (array) json_decode( wp_unslash( $_POST['all_cookies'] ) ) ) : array(); // WPCS: Input var ok, sanitization ok.
 
-		$approved_cookies = array();
-		if ( ! empty( $cookies ) ) {
-			foreach ( $cookies as $cookie_array ) {
-				$cookie_array = json_decode( wp_unslash( $cookie_array ) );
-				foreach ( $cookie_array as $cookie ) {
-					$approved_cookies[] = $cookie;
+		/**
+		 * Prints the privacy bar for the end user to save the consent and cookie settings.
+		 *
+		 * @since  1.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 */
+		public function privacy_bar () {
+
+			$privacy_bar_enabled        = get_option( 'gdpr_enable_privacy_bar', true );
+			$content                    = get_option( 'gdpr_cookie_banner_content', '' );
+			$registered_cookies         = get_option( 'gdpr_cookie_popup_content', [] );
+			$show_cookie_cat_checkboxes = get_option( 'gdpr_display_cookie_categories_in_bar', false );
+			$button_text                = apply_filters( 'gdpr_privacy_bar_button_text', esc_html__( 'I Agree', 'gdpr' ) );
+			$privacy_bar_enabled        = apply_filters( 'gdpr_privacy_bar_display', $privacy_bar_enabled );
+			$hide_from_bots             = get_option( 'gdpr_hide_from_bots', true );
+			$show_eu_only               = get_option( 'gdpr_show_eu_only', true );
+
+			if ( ! $privacy_bar_enabled || ( $hide_from_bots && $this->is_crawler() ) || ( $show_eu_only && ! $this->is_eu_visitor() ) ) {
+				return;
+			}
+
+			GDPR_Templates::get_template( 'privacy-bar.php', [
+				'content'                    => $content,
+				'registered_cookies'         => $registered_cookies,
+				'show_cookie_cat_checkboxes' => $show_cookie_cat_checkboxes,
+				'button_text'                => $button_text,
+			] );
+		}
+
+		/**
+		 * The privacy preferences modal.
+		 *
+		 * @since  1.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 */
+		public function privacy_preferences_modal () {
+
+			$cookie_privacy_excerpt = get_option( 'gdpr_cookie_privacy_excerpt', '' );
+			$consent_types          = get_option( 'gdpr_consent_types', [] );
+			$approved_cookies       = isset( $_COOKIE[ 'gdpr' ][ 'allowed_cookies' ] ) ? json_decode( wp_unslash( $_COOKIE[ 'gdpr' ][ 'allowed_cookies' ] ) ) : []; // WPCS: Input var ok, sanitization ok..
+			$user_consents          = isset( $_COOKIE[ 'gdpr' ][ 'consent_types' ] ) ? json_decode( wp_unslash( $_COOKIE[ 'gdpr' ][ 'consent_types' ] ) ) : []; // WPCS: Input var ok, sanitization ok.
+			$tabs                   = get_option( 'gdpr_cookie_popup_content', [] );
+			$hide_from_bots         = get_option( 'gdpr_hide_from_bots', true );
+			$show_eu_only           = get_option( 'gdpr_show_eu_only', true );
+
+			if ( ( $hide_from_bots && $this->is_crawler() ) || ( $show_eu_only && ! $this->is_eu_visitor() ) ) {
+				return;
+			}
+
+			GDPR_Templates::get_template( 'privacy-preferences-modal.php', [
+				'cookie_privacy_excerpt' => $cookie_privacy_excerpt,
+				'consent_types'          => $consent_types,
+				'approved_cookies'       => $approved_cookies,
+				'user_consents'          => $user_consents,
+				'tabs'                   => $tabs,
+				'allowed_html'           => $this->allowed_html,
+			] );
+		}
+
+		/**
+		 * Detect if the visitor is from EU
+		 *
+		 * Requires pecl php-geoip package to be installed, or using a apply a custom detection using filter
+		 *
+		 * @return bool
+		 * @author Yaniv Harush <harushy@gmail.com>
+		 */
+		public function is_eu_visitor () {
+
+			if ( function_exists( 'geoip_continent_code_by_name' ) ) {
+				return ( geoip_continent_code_by_name( $this->get_visitor_ip() ) === 'EU' );
+			} else {
+				return apply_filters( 'geoip_is_eu_visitor', false );
+			}
+		}
+
+		/**
+		 * Get visitor IP Address
+		 *
+		 * @return string ip address
+		 * @author Yaniv Harush <harushy@gmail.com>
+		 */
+		public function get_visitor_ip () {
+
+			if ( ! empty( $_SERVER[ 'HTTP_CF_CONNECTING_IP' ] ) ) {
+				return $_SERVER[ 'HTTP_CF_CONNECTING_IP' ];
+			} else if ( ! empty( $_SERVER[ 'HTTP_X_REAL_IP' ] ) ) {
+				return $_SERVER[ 'HTTP_X_REAL_IP' ];
+			} else if ( ! empty( $_SERVER[ 'HTTP_CLIENT_IP' ] ) ) {
+				return $_SERVER[ 'HTTP_CLIENT_IP' ];
+			} else if ( ! empty( $_SERVER[ 'HTTP_X_FORWARDED_FOR' ] ) ) {
+				return $_SERVER[ 'HTTP_X_FORWARDED_FOR' ];
+			}
+
+			return $_SERVER[ 'REMOTE_ADDR' ];
+		}
+
+		/**
+		 * The black overlay for the plugin modals.
+		 *
+		 * @since  1.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 */
+		public function overlay () {
+
+			echo '<div class="gdpr gdpr-overlay"></div>';
+		}
+
+		/**
+		 * Prints the confirmation dialogs.
+		 *
+		 * @since  1.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 */
+		public function confirmation_screens () {
+
+			require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/partials/confirmation-screens.php';
+		}
+
+		/**
+		 * Update the user allowed cookies and types of consent.
+		 * If the user is logged in, we also save consent to user meta.
+		 * Ajax version of a previous function.
+		 *
+		 * @since  2.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 */
+		public function update_privacy_preferences () {
+
+			if ( ! isset( $_POST[ 'update-privacy-preferences-nonce' ] ) || ! wp_verify_nonce( sanitize_key( $_POST[ 'update-privacy-preferences-nonce' ] ), 'gdpr-update-privacy-preferences' ) ) { // WPCS: Input var ok.
+				wp_send_json_error(
+					[
+						'title'   => esc_html__( 'Error!', 'gdpr' ),
+						'content' => esc_html__( 'We could not verify the security token. Please try again.', 'gdpr' ),
+					]
+				);
+			}
+			$consents    = isset( $_POST[ 'user_consents' ] ) ? array_map( 'sanitize_text_field', (array) wp_unslash( $_POST[ 'user_consents' ] ) ) : []; // WPCS: Input var ok.
+			$cookies     = isset( $_POST[ 'approved_cookies' ] ) ? array_map( 'sanitize_text_field', (array) wp_unslash( $_POST[ 'approved_cookies' ] ) ) : []; // WPCS: Input var ok.
+			$all_cookies = isset( $_POST[ 'all_cookies' ] ) ? array_map( 'sanitize_text_field', (array) json_decode( wp_unslash( $_POST[ 'all_cookies' ] ) ) ) : []; // WPCS: Input var ok, sanitization ok.
+
+			$approved_cookies = [];
+			if ( ! empty( $cookies ) ) {
+				foreach ( $cookies as $cookie_array ) {
+					$cookie_array = json_decode( wp_unslash( $cookie_array ) );
+					foreach ( $cookie_array as $cookie ) {
+						$approved_cookies[] = $cookie;
+					}
 				}
 			}
-		}
 
-		$cookies_to_remove = array_diff( $all_cookies, $approved_cookies );
+			$cookies_to_remove = array_diff( $all_cookies, $approved_cookies );
 
-		$cookies_as_json  = json_encode( $approved_cookies );
-		$consents_as_json = json_encode( $consents );
+			$cookies_as_json  = json_encode( $approved_cookies );
+			$consents_as_json = json_encode( $consents );
 
-		setcookie( 'gdpr[allowed_cookies]', $cookies_as_json, time() + YEAR_IN_SECONDS, '/' );
-		setcookie( 'gdpr[consent_types]', $consents_as_json, time() + YEAR_IN_SECONDS, '/' );
+			setcookie( 'gdpr[allowed_cookies]', $cookies_as_json, time() + YEAR_IN_SECONDS, '/' );
+			setcookie( 'gdpr[consent_types]', $consents_as_json, time() + YEAR_IN_SECONDS, '/' );
 
-		foreach ( $cookies_to_remove as $cookie ) {
-			if ( GDPR::similar_in_array( $cookie, array_keys( $_COOKIE ) ) ) { // WPCS: Input var ok.
-				$domain = get_site_url();
-				$domain = wp_parse_url( $domain, PHP_URL_HOST );
-				unset( $_COOKIE[ $cookie ] ); // WPCS: Input var ok.
-				setcookie( $cookie, null, -1, '/', $domain );
-				setcookie( $cookie, null, -1, '/', '.' . $domain );
-			}
-		}
-
-		if ( is_user_logged_in() ) {
-			$user = wp_get_current_user();
-			GDPR_Audit_Log::log( $user->ID, esc_html__( 'User updated their privacy preferences. These are the new approved cookies and consent preferences:', 'gdpr' ) );
-			if ( ! empty( $consents ) ) {
-				delete_user_meta( $user->ID, 'gdpr_consents' );
-				foreach ( $consents as $consent ) {
-					$consent = sanitize_text_field( wp_unslash( $consent ) );
-					add_user_meta( $user->ID, 'gdpr_consents', $consent );
-					GDPR_Audit_Log::log( $user->ID, 'Consent: ' . $consent );
+			foreach ( $cookies_to_remove as $cookie ) {
+				if ( GDPR::similar_in_array( $cookie, array_keys( $_COOKIE ) ) ) { // WPCS: Input var ok.
+					$domain = get_site_url();
+					$domain = wp_parse_url( $domain, PHP_URL_HOST );
+					unset( $_COOKIE[ $cookie ] ); // WPCS: Input var ok.
+					setcookie( $cookie, null, - 1, '/', $domain );
+					setcookie( $cookie, null, - 1, '/', '.' . $domain );
 				}
 			}
 
-			if ( ! empty( $approved_cookies ) ) {
-				foreach ( $approved_cookies as $cookie ) {
-					GDPR_Audit_Log::log( $user->ID, 'Cookie: ' . $cookie );
+			if ( is_user_logged_in() ) {
+				$user = wp_get_current_user();
+				GDPR_Audit_Log::log( $user->ID, esc_html__( 'User updated their privacy preferences. These are the new approved cookies and consent preferences:', 'gdpr' ) );
+				if ( ! empty( $consents ) ) {
+					delete_user_meta( $user->ID, 'gdpr_consents' );
+					foreach ( $consents as $consent ) {
+						$consent = sanitize_text_field( wp_unslash( $consent ) );
+						add_user_meta( $user->ID, 'gdpr_consents', $consent );
+						GDPR_Audit_Log::log( $user->ID, 'Consent: ' . $consent );
+					}
+				}
+
+				if ( ! empty( $approved_cookies ) ) {
+					foreach ( $approved_cookies as $cookie ) {
+						GDPR_Audit_Log::log( $user->ID, 'Cookie: ' . $cookie );
+					}
 				}
 			}
+
+			wp_send_json_success();
 		}
 
-		wp_send_json_success();
-	}
+		/**
+		 * Check if the user did not consent to the privacy policy
+		 *
+		 * @since  1.0.0
+		 * @author Fernando Claussen <fernandoclaussen@gmail.com>
+		 * @return bool     Whether the user consented or not.
+		 */
+		public function is_consent_needed () {
 
-	/**
-	 * Check if the user did not consent to the privacy policy
-	 * @since  1.0.0
-	 * @author Fernando Claussen <fernandoclaussen@gmail.com>
-	 * @return bool     Whether the user consented or not.
-	 */
-	public function is_consent_needed() {
-		$consents = get_option( 'gdpr_consent_types', array() );
-		if ( empty( $consents ) || ! is_array( $consents ) ) {
-			return;
-		}
-		$required_consents = array_filter(
-			$consents, function( $consent ) {
-				return ! empty( $consent['policy-page'] );
+			$consents = get_option( 'gdpr_consent_types', [] );
+			if ( empty( $consents ) || ! is_array( $consents ) ) {
+				return;
 			}
-		);
+			$required_consents = array_filter(
+				$consents, function ( $consent ) {
 
-		if ( ! $required_consents || ! is_user_logged_in() ) {
-			return;
-		}
+				return ! empty( $consent[ 'policy-page' ] );
+			}
+			);
 
-		$user          = wp_get_current_user();
-		$user_consents = get_user_meta( $user->ID, 'gdpr_consents' );
+			if ( ! $required_consents || ! is_user_logged_in() ) {
+				return;
+			}
 
-		if ( ! is_array( $user_consents ) ) {
-			return;
-		}
+			$user          = wp_get_current_user();
+			$user_consents = get_user_meta( $user->ID, 'gdpr_consents' );
 
-		$updated_consents = array_filter(
-			$required_consents, function( $consent, $consent_id ) use ( $user_consents ) {
+			if ( ! is_array( $user_consents ) ) {
+				return;
+			}
+
+			$updated_consents = array_filter(
+				$required_consents, function ( $consent, $consent_id ) use ( $user_consents ) {
+
 				return ! in_array( $consent_id, $user_consents, true );
 			}, ARRAY_FILTER_USE_BOTH
-		);
+			);
 
-		if ( empty( $updated_consents ) ) {
-			return;
-		}
-
-		$reconsent_template = get_option( 'gdpr_reconsent_template', 'modal' );
-
-		if ( 'bar' === $reconsent_template ) {
-			GDPR_Templates::get_template( 'reconsent-bar.php', array(
-				'updated_consents' => $updated_consents,
-			) );
-		} else {
-			GDPR_Templates::get_template( 'reconsent-modal.php', array(
-				'updated_consents' => $updated_consents,
-			) );
-		}
-
-	}
-
-	protected function is_crawler() {
-	  return ( isset( $_SERVER['HTTP_USER_AGENT'] ) && preg_match('/bot|crawl|slurp|spider|mediapartners/i', $_SERVER['HTTP_USER_AGENT'] ) );
-	}
-
-	public function set_plugin_cookies() {
-		$user_id = get_current_user_id();
-
-		if ( ! isset( $_COOKIE['gdpr']['consent_types'] ) ) { // WPCS: Input var ok.
-			if ( ! $user_id ) {
-				setcookie( 'gdpr[consent_types]', '[]', time() + YEAR_IN_SECONDS, '/' );
-			} else {
-				$user_consents = get_user_meta( $user_id, 'gdpr_consents' );
-				setcookie( 'gdpr[consent_types]', json_encode( $user_consents ), time() + YEAR_IN_SECONDS, '/' );
+			if ( empty( $updated_consents ) ) {
+				return;
 			}
-		} else {
-			if ( $user_id ) {
-				$user_consents   = (array) get_user_meta( $user_id, 'gdpr_consents' );
-				$cookie_consents = (array) json_decode( wp_unslash( $_COOKIE['gdpr']['consent_types'] ) ); // WPCS: Input var ok, sanitization ok.
 
-				$intersect = array_intersect( $user_consents, $cookie_consents );
-				$diff      = array_merge( array_diff( $user_consents, $intersect ), array_diff( $cookie_consents, $intersect ) );
+			$reconsent_template = get_option( 'gdpr_reconsent_template', 'modal' );
 
-				if ( ! empty( $diff ) ) {
+			if ( 'bar' === $reconsent_template ) {
+				GDPR_Templates::get_template( 'reconsent-bar.php', [
+					'updated_consents' => $updated_consents,
+				] );
+			} else {
+				GDPR_Templates::get_template( 'reconsent-modal.php', [
+					'updated_consents' => $updated_consents,
+				] );
+			}
+		}
+
+		protected function is_crawler () {
+
+			return ( isset( $_SERVER[ 'HTTP_USER_AGENT' ] ) && preg_match( '/bot|crawl|slurp|spider|mediapartners/i', $_SERVER[ 'HTTP_USER_AGENT' ] ) );
+		}
+
+		public function set_plugin_cookies () {
+
+			$user_id = get_current_user_id();
+
+			if ( ! isset( $_COOKIE[ 'gdpr' ][ 'consent_types' ] ) ) { // WPCS: Input var ok.
+				if ( ! $user_id ) {
+					setcookie( 'gdpr[consent_types]', '[]', time() + YEAR_IN_SECONDS, '/' );
+				} else {
+					$user_consents = get_user_meta( $user_id, 'gdpr_consents' );
 					setcookie( 'gdpr[consent_types]', json_encode( $user_consents ), time() + YEAR_IN_SECONDS, '/' );
 				}
-			}
-		}
+			} else {
+				if ( $user_id ) {
+					$user_consents   = (array) get_user_meta( $user_id, 'gdpr_consents' );
+					$cookie_consents = (array) json_decode( wp_unslash( $_COOKIE[ 'gdpr' ][ 'consent_types' ] ) ); // WPCS: Input var ok, sanitization ok.
 
-		if ( ! isset( $_COOKIE['gdpr']['allowed_cookies'] ) ) { // WPCS: Input var ok.
-			$registered_cookies = get_option( 'gdpr_cookie_popup_content', array() );
-			$cookies            = array();
-			if ( ! empty( $registered_cookies ) ) {
-				$required_cookies = array_filter(
-					$registered_cookies, function( $item ) {
-						return 'required' === $item['status'] || 'soft' === $item['status'];
+					$intersect = array_intersect( $user_consents, $cookie_consents );
+					$diff      = array_merge( array_diff( $user_consents, $intersect ), array_diff( $cookie_consents, $intersect ) );
+
+					if ( ! empty( $diff ) ) {
+						setcookie( 'gdpr[consent_types]', json_encode( $user_consents ), time() + YEAR_IN_SECONDS, '/' );
 					}
-				);
-				if ( ! empty( $required_cookies ) ) {
-					foreach ( $required_cookies as $category ) {
-						$cookies_used = explode( ',', $category['cookies_used'] );
-						foreach ( $cookies_used as $cookie ) {
-							$cookies[] = trim( $cookie );
+				}
+			}
+
+			if ( ! isset( $_COOKIE[ 'gdpr' ][ 'allowed_cookies' ] ) ) { // WPCS: Input var ok.
+				$registered_cookies = get_option( 'gdpr_cookie_popup_content', [] );
+				$cookies            = [];
+				if ( ! empty( $registered_cookies ) ) {
+					$required_cookies = array_filter(
+						$registered_cookies, function ( $item ) {
+
+						return 'required' === $item[ 'status' ] || 'soft' === $item[ 'status' ];
+					}
+					);
+					if ( ! empty( $required_cookies ) ) {
+						foreach ( $required_cookies as $category ) {
+							$cookies_used = explode( ',', $category[ 'cookies_used' ] );
+							foreach ( $cookies_used as $cookie ) {
+								$cookies[] = trim( $cookie );
+							}
 						}
 					}
 				}
+
+				if ( ! empty( $cookies ) ) {
+					setcookie( 'gdpr[allowed_cookies]', json_encode( $cookies ), time() + YEAR_IN_SECONDS, '/' );
+				} else {
+					setcookie( 'gdpr[allowed_cookies]', '[]', time() + YEAR_IN_SECONDS, '/' );
+				}
+			}
+		}
+
+		public function agree_with_new_policies () {
+
+			if ( ! isset( $_POST[ 'nonce' ] ) || ! wp_verify_nonce( sanitize_key( $_POST[ 'nonce' ] ), 'gdpr-agree-with-new-policies' ) ) { // WPCS: Input var ok.
+				wp_send_json_error(
+					[
+						'title'   => esc_html__( 'Error!', 'gdpr' ),
+						'content' => esc_html__( 'We could not verify the security token. Please try again.', 'gdpr' ),
+					]
+				);
+			}
+			$consents = isset( $_POST[ 'consents' ] ) ? array_map( 'sanitize_text_field', (array) wp_unslash( $_POST[ 'consents' ] ) ) : []; // WPCS: Input var ok.
+			$user_id  = get_current_user_id();
+
+			foreach ( $consents as $consent ) {
+				add_user_meta( $user_id, 'gdpr_consents', $consent );
+				GDPR_Audit_Log::log( $user_id, sprintf( esc_html__( 'User provided new consent for %1$s.', 'gdpr' ), esc_html( $consent ) ) );
 			}
 
-			if ( ! empty( $cookies ) ) {
-				setcookie( 'gdpr[allowed_cookies]', json_encode( $cookies ), time() + YEAR_IN_SECONDS, '/' );
-			} else {
-				setcookie( 'gdpr[allowed_cookies]', '[]', time() + YEAR_IN_SECONDS, '/' );
-			}
+			wp_send_json_success();
 		}
+
 	}
-
-	public function agree_with_new_policies() {
-		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), 'gdpr-agree-with-new-policies' ) ) { // WPCS: Input var ok.
-			wp_send_json_error(
-				array(
-					'title'   => esc_html__( 'Error!', 'gdpr' ),
-					'content' => esc_html__( 'We could not verify the security token. Please try again.', 'gdpr' ),
-				)
-			);
-		}
-		$consents = isset( $_POST['consents'] ) ? array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['consents'] ) ) : array(); // WPCS: Input var ok.
-		$user_id  = get_current_user_id();
-
-		foreach ( $consents as $consent ) {
-			add_user_meta( $user_id, 'gdpr_consents', $consent );
-			GDPR_Audit_Log::log( $user_id, sprintf( esc_html__( 'User provided new consent for %1$s.', 'gdpr' ), esc_html( $consent ) ) );
-		}
-
-		wp_send_json_success();
-	}
-
-}

--- a/public/class-gdpr-public.php
+++ b/public/class-gdpr-public.php
@@ -222,7 +222,7 @@
 			if ( function_exists( 'geoip_continent_code_by_name' ) ) {
 				return ( geoip_continent_code_by_name( $this->get_visitor_ip() ) === 'EU' );
 			} else {
-				return apply_filters( 'geoip_is_eu_visitor', false );
+				return apply_filters( 'geoip_is_eu_visitor', false, $this->get_visitor_ip() );
 			}
 		}
 

--- a/public/class-gdpr-public.php
+++ b/public/class-gdpr-public.php
@@ -222,7 +222,7 @@
 			if ( function_exists( 'geoip_continent_code_by_name' ) ) {
 				return ( geoip_continent_code_by_name( $this->get_visitor_ip() ) === 'EU' );
 			} else {
-				return apply_filters( 'geoip_is_eu_visitor', false, $this->get_visitor_ip() );
+				return apply_filters( 'gdpr_is_eu_visitor', false, $this->get_visitor_ip() );
 			}
 		}
 

--- a/public/class-gdpr-public.php
+++ b/public/class-gdpr-public.php
@@ -234,17 +234,7 @@
 		 */
 		public function get_visitor_ip () {
 
-			if ( ! empty( $_SERVER[ 'HTTP_CF_CONNECTING_IP' ] ) ) {
-				return $_SERVER[ 'HTTP_CF_CONNECTING_IP' ];
-			} else if ( ! empty( $_SERVER[ 'HTTP_X_REAL_IP' ] ) ) {
-				return $_SERVER[ 'HTTP_X_REAL_IP' ];
-			} else if ( ! empty( $_SERVER[ 'HTTP_CLIENT_IP' ] ) ) {
-				return $_SERVER[ 'HTTP_CLIENT_IP' ];
-			} else if ( ! empty( $_SERVER[ 'HTTP_X_FORWARDED_FOR' ] ) ) {
-				return $_SERVER[ 'HTTP_X_FORWARDED_FOR' ];
-			}
-
-			return $_SERVER[ 'REMOTE_ADDR' ];
+			return $_SERVER[ "HTTP_CF_CONNECTING_IP" ] ?? $_SERVER[ "HTTP_X_REAL_IP" ] ?? $_SERVER[ "HTTP_X_FORWARDED_FOR" ] ?? $_SERVER[ "HTTP_CLIENT_IP" ] ?? $_SERVER[ "REMOTE_ADDR" ] ?? null;
 		}
 
 		/**


### PR DESCRIPTION
- added checkbox in admin settings
- added IP detection function
- added is_eu_visitor() function. this function requires pecl PHP-GEOIP package. if the package is not installed, using a custom detection method hooked to the 'gdpr_is_eu_visitor' filter. 

* for some reasons I had to manually create the admin option in the database ("gdpr_show_eu_only"). it didn't create automatically. 