### PR TITLE
allow html and enable wp editor for textareas

### DIFF
--- a/admin/class-gdpr-admin.php
+++ b/admin/class-gdpr-admin.php
@@ -64,9 +64,106 @@ class GDPR_Admin {
 		$this->allowed_html = apply_filters( 'gdpr_allowed_html',
 			array(
 				'a' => array(
-					'href'   => true,
-					'title'  => true,
-					'target' => true,
+					'id'     => array(),
+					'class'  => array(),
+					'href'   => array(),
+					'rel'    => array(),
+					'rev'    => array(),
+					'name'   => array(),
+					'title'  => array(),
+					'target' => array(),
+				),
+				'div' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'span' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'i' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'p' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'br' => array(),
+				'hr' => array(
+					'class'  => array(),
+				),
+				'em' => array(),
+				'strong' => array(),
+				'small' => array(),
+				'strike' => array(),
+				'ul' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'ol' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'start'  => array(),
+				),
+				'li' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'value'  => array(),
+				),
+				'img' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'alt'    => array(),
+					'height' => array(),
+					'src'    => array(),
+					'width'  => array(),
+					'title'  => array(),
+				),
+				'h1' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'h2' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'h3' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'h4' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'h5' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'h6' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'label' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'for'    => array(),
+				),
+				'code' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'button' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'name'   => array(),
+					'value'  => array(),
+					'disabled'  => array(),
+				),
+				'abbr' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'title'  => array(),
 				),
 			)
 		);
@@ -188,7 +285,7 @@ class GDPR_Admin {
 	public function register_settings() {
 		$settings = array(
 			'gdpr_cookie_banner_content'               => array( $this, 'sanitize_with_links' ),
-			'gdpr_cookie_privacy_excerpt'              => 'sanitize_textarea_field',
+			'gdpr_cookie_privacy_excerpt'              => array( $this, 'sanitize_with_links' ),
 			'gdpr_cookie_popup_content'                => array( $this, 'sanitize_cookie_categories' ),
 			'gdpr_email_limit'                         => 'intval',
 			'gdpr_consent_types'                       => array( $this, 'sanitize_consents' ),

--- a/admin/class-gdpr-admin.php
+++ b/admin/class-gdpr-admin.php
@@ -60,12 +60,15 @@ class GDPR_Admin {
 	public function __construct( $plugin_name, $version ) {
 		$this->plugin_name  = $plugin_name;
 		$this->version      = $version;
-		$this->allowed_html = array(
-			'a' => array(
-				'href'   => true,
-				'title'  => true,
-				'target' => true,
-			),
+		$tabs = apply_filters( 'gdpr_tools_tabs', $tabs );
+		$this->allowed_html = apply_filters( 'gdpr_allowed_html',
+			array(
+				'a' => array(
+					'href'   => true,
+					'title'  => true,
+					'target' => true,
+				),
+			)
 		);
 	}
 

--- a/admin/class-gdpr-admin.php
+++ b/admin/class-gdpr-admin.php
@@ -361,6 +361,26 @@ class GDPR_Admin {
 		include_once plugin_dir_path( __FILE__ ) . 'partials/templates/tmpl-cookies.php';
 		include_once plugin_dir_path( __FILE__ ) . 'partials/templates/tmpl-consents.php';
 
+		/**
+		 * Extend tinymce valid elements to match our allowed_html.
+		 */
+		add_filter( 'tiny_mce_before_init', function( $initArray ) {
+			$extended_valid_elements = '';
+			foreach ( $this->allowed_html as $element => $attributes ) {
+				if ( strlen( $extended_valid_elements ) > 0 ) {
+					$extended_valid_elements .= ',';
+				}
+				$extended_valid_elements .= $element;
+				if ( is_array( $attributes ) && count( $attributes ) > 0 ) {
+					$extended_valid_elements .= '[' . implode( '|', array_keys( $attributes ) ) . ']';
+				}
+			}
+			$initArray['extended_valid_elements'] = $extended_valid_elements;
+			$initArray['entity_encoding'] = 'raw';
+
+			return $initArray;
+		}, 20, 1 );
+
 		include plugin_dir_path( __FILE__ ) . 'partials/settings.php';
 	}
 

--- a/admin/partials/settings.php
+++ b/admin/partials/settings.php
@@ -145,7 +145,7 @@
 					</th>
 					<td>
 						<?php $privacy_excerpt = get_option( 'gdpr_cookie_privacy_excerpt', '' ); ?>
-						<textarea name="gdpr_cookie_privacy_excerpt" id="gdpr_cookie_privacy_excerpt" cols="80" rows="6"><?php echo esc_html( $privacy_excerpt ); ?></textarea>
+						<textarea name="gdpr_cookie_privacy_excerpt" id="gdpr_cookie_privacy_excerpt" cols="80" rows="6"><?php echo esc_textarea( $privacy_excerpt ); ?></textarea>
 						<p class="description"><?php esc_html_e( 'This will appear in the consent section of the privacy preference window.', 'gdpr' ); ?></p>
 					</td>
 				</tr>

--- a/admin/partials/settings.php
+++ b/admin/partials/settings.php
@@ -132,7 +132,20 @@
 					</th>
 					<td>
 						<?php $privacy_bar_content = get_option( 'gdpr_cookie_banner_content', '' ); ?>
-						<textarea name="gdpr_cookie_banner_content" id="gdpr_cookie_banner_content" cols="80" rows="6"><?php echo esc_textarea( $privacy_bar_content ); ?></textarea>
+						<?php
+							if ( user_can_richedit() ):
+								wp_editor( $privacy_bar_content, 'gdpr_cookie_banner_content',
+									array(
+										'textarea_name' => 'gdpr_cookie_banner_content',
+										'textarea_rows' => '6',
+									)
+								);
+							else:
+						?>
+								<textarea name="gdpr_cookie_banner_content" id="gdpr_cookie_banner_content" cols="80" rows="6"><?php echo esc_textarea( $privacy_bar_content ); ?></textarea>
+						<?php
+							endif;
+						?>
 					</td>
 				</tr>
 				<tr>
@@ -145,7 +158,18 @@
 					</th>
 					<td>
 						<?php $privacy_excerpt = get_option( 'gdpr_cookie_privacy_excerpt', '' ); ?>
-						<textarea name="gdpr_cookie_privacy_excerpt" id="gdpr_cookie_privacy_excerpt" cols="80" rows="6"><?php echo esc_textarea( $privacy_excerpt ); ?></textarea>
+						<?php
+							if ( user_can_richedit() ):
+								wp_editor( $privacy_excerpt, 'gdpr_cookie_privacy_excerpt', array(
+									'textarea_name' => 'gdpr_cookie_privacy_excerpt',
+									'textarea_rows' => '6',
+								) );
+							else:
+						?>
+								<textarea name="gdpr_cookie_privacy_excerpt" id="gdpr_cookie_privacy_excerpt" cols="80" rows="6"><?php echo esc_textarea( $privacy_excerpt ); ?></textarea>
+						<?php
+							endif;
+						?>
 						<p class="description"><?php esc_html_e( 'This will appear in the consent section of the privacy preference window.', 'gdpr' ); ?></p>
 					</td>
 				</tr>
@@ -291,7 +315,22 @@
 										</span>
 									</label>
 								</th>
-								<td><textarea name="gdpr_cookie_popup_content[<?php echo esc_attr( $cat_id ); ?>][how_we_use]" id="tab-how-we-use-<?php echo esc_attr( $cat_id ); ?>" cols="53" rows="3"><?php echo esc_html( $registered_cookies[ $cat_id ]['how_we_use'] ); ?></textarea></td>
+								<td>
+								<?php
+									if ( user_can_richedit() ):
+										wp_editor( $registered_cookies[ $cat_id ]['how_we_use'], 'tab-how-we-use-' . esc_attr( $cat_id ),
+											array(
+												'textarea_name' => 'gdpr_cookie_popup_content[' . esc_attr( $cat_id ) . '][how_we_use]',
+												'textarea_rows' => '6',
+											)
+										);
+									else:
+								?>
+									<textarea name="gdpr_cookie_popup_content[<?php echo esc_attr( $cat_id ); ?>][how_we_use]" id="tab-how-we-use-<?php echo esc_attr( $cat_id ); ?>" cols="53" rows="3"><?php echo esc_html( $registered_cookies[ $cat_id ]['how_we_use'] ); ?></textarea>
+								<?php
+									endif;
+								?>
+								</td>
 							</tr>
 							<tr>
 				<th>
@@ -400,7 +439,22 @@
 											</span>
 										</label>
 									</th>
-									<td><textarea name="gdpr_consent_types[<?php echo esc_attr( $consent_id ); ?>][description]" id="consent-description-<?php echo esc_attr( $consent_id ); ?>" cols="53" rows="3" required><?php echo esc_html( $consent['description'] ); ?></textarea></td>
+									<td>
+									<?php
+										if ( user_can_richedit() ):
+											wp_editor( $consent['description'], 'consent-description-' . esc_attr( $consent_id ),
+												array(
+													'textarea_name' => 'gdpr_consent_types[' . esc_attr( $consent_id ) . '][description]',
+													'textarea_rows' => '6',
+												)
+											);
+										else:
+									?>
+											<textarea name="gdpr_consent_types[<?php echo esc_attr( $consent_id ); ?>][description]" id="consent-description-<?php echo esc_attr( $consent_id ); ?>" cols="53" rows="3" required><?php echo esc_html( $consent['description'] ); ?></textarea>
+									<?php
+										endif;
+									?>
+									</td>
 								</tr>
 								<tr>
 									<th>
@@ -412,7 +466,22 @@
 											</span>
 										</label>
 									</th>
-									<td><textarea name="gdpr_consent_types[<?php echo esc_attr( $consent_id ); ?>][registration]" id="consent-registration-<?php echo esc_attr( $consent_id ); ?>" cols="53" rows="3" required><?php echo esc_html( $consent['registration'] ); ?></textarea></td>
+									<td>
+									<?php
+										if ( user_can_richedit() ):
+											wp_editor( $consent['registration'], 'consent-registration-' . esc_attr( $consent_id ),
+												array(
+													'textarea_name' => 'gdpr_consent_types[' . esc_attr( $consent_id ) . '][registration]',
+													'textarea_rows' => '6',
+												)
+											);
+										else:
+									?>
+											<textarea name="gdpr_consent_types[<?php echo esc_attr( $consent_id ); ?>][registration]" id="consent-registration-<?php echo esc_attr( $consent_id ); ?>" cols="53" rows="3" required><?php echo esc_html( $consent['registration'] ); ?></textarea>
+									<?php
+										endif;
+									?>
+									</td>
 								</tr>
 							</table>
 						</div><!-- .inside -->

--- a/admin/partials/settings.php
+++ b/admin/partials/settings.php
@@ -132,7 +132,7 @@
 					</th>
 					<td>
 						<?php $privacy_bar_content = get_option( 'gdpr_cookie_banner_content', '' ); ?>
-						<textarea name="gdpr_cookie_banner_content" id="gdpr_cookie_banner_content" cols="80" rows="6"><?php echo esc_html( $privacy_bar_content ); ?></textarea>
+						<textarea name="gdpr_cookie_banner_content" id="gdpr_cookie_banner_content" cols="80" rows="6"><?php echo esc_textarea( $privacy_bar_content ); ?></textarea>
 					</td>
 				</tr>
 				<tr>

--- a/public/class-gdpr-public.php
+++ b/public/class-gdpr-public.php
@@ -67,9 +67,106 @@ class GDPR_Public {
 		$this->allowed_html = apply_filters( 'gdpr_allowed_html',
 			array(
 				'a' => array(
-					'href'   => true,
-					'title'  => true,
-					'target' => true,
+					'id'     => array(),
+					'class'  => array(),
+					'href'   => array(),
+					'rel'    => array(),
+					'rev'    => array(),
+					'name'   => array(),
+					'title'  => array(),
+					'target' => array(),
+				),
+				'div' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'span' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'i' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'p' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'br' => array(),
+				'hr' => array(
+					'class'  => array(),
+				),
+				'em' => array(),
+				'strong' => array(),
+				'small' => array(),
+				'strike' => array(),
+				'ul' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'ol' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'start'  => array(),
+				),
+				'li' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'value'  => array(),
+				),
+				'img' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'alt'    => array(),
+					'height' => array(),
+					'src'    => array(),
+					'width'  => array(),
+					'title'  => array(),
+				),
+				'h1' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'h2' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'h3' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'h4' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'h5' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'h6' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'label' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'for'    => array(),
+				),
+				'code' => array(
+					'id'     => array(),
+					'class'  => array(),
+				),
+				'button' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'name'   => array(),
+					'value'  => array(),
+					'disabled'  => array(),
+				),
+				'abbr' => array(
+					'id'     => array(),
+					'class'  => array(),
+					'title'  => array(),
 				),
 			)
 		);
@@ -168,6 +265,7 @@ class GDPR_Public {
 			'registered_cookies' => $registered_cookies,
 			'show_cookie_cat_checkboxes' => $show_cookie_cat_checkboxes,
 			'button_text' => $button_text,
+			'allowed_html' => $this->allowed_html,
 		) );
 	}
 

--- a/public/class-gdpr-public.php
+++ b/public/class-gdpr-public.php
@@ -64,12 +64,14 @@ class GDPR_Public {
 	public function __construct( $plugin_name, $version ) {
 		$this->plugin_name  = $plugin_name;
 		$this->version      = $version;
-		$this->allowed_html = array(
-			'a' => array(
-				'href'   => true,
-				'title'  => true,
-				'target' => true,
-			),
+		$this->allowed_html = apply_filters( 'gdpr_allowed_html',
+			array(
+				'a' => array(
+					'href'   => true,
+					'title'  => true,
+					'target' => true,
+				),
+			)
 		);
 	}
 

--- a/templates/privacy-bar.php
+++ b/templates/privacy-bar.php
@@ -15,7 +15,7 @@
 <div class="gdpr gdpr-privacy-bar" style="display:none;">
 	<div class="gdpr-wrapper">
 		<div class="gdpr-content">
-			<p><?php echo nl2br( wp_kses_post( $args['content'] ) ); ?></p>
+			<p><?php echo nl2br( wp_kses( $args['content'], $args['allowed_html'] ) ); ?></p>
 		</div>
 		<div class="gdpr-right">
 			<?php if ( $args['show_cookie_cat_checkboxes'] ) : ?>

--- a/templates/privacy-preferences-modal.php
+++ b/templates/privacy-preferences-modal.php
@@ -65,7 +65,7 @@
 							<h4><?php esc_html_e( 'Consent Management', 'gdpr' ); ?></h4>
 						</header>
 						<div class="gdpr-info">
-							<p><?php echo nl2br( esc_html( $args['cookie_privacy_excerpt'] ) ); ?></p>
+							<p><?php echo nl2br( wp_kses( $args['cookie_privacy_excerpt'], $args['allowed_html'] ) ); ?></p>
 							<?php if ( ! empty( $args['consent_types'] ) ) : ?>
 								<?php foreach ( $args['consent_types'] as $consent_key => $type ) : ?>
 									<div class="gdpr-cookies-used">


### PR DESCRIPTION
This expands the allowed html in textareas, adds a filter so users can specify their own allowed_html, and adds the visual editor to textareas.