### PR TITLE
Adds data attribute with function to call to close notification modal

### DIFF
--- a/public/partials/confirmation-screens.php
+++ b/public/partials/confirmation-screens.php
@@ -55,7 +55,7 @@ if ( isset( $_GET['notify'] ) && absint( $_GET['notify'] ) ) : // WPCS: Input va
 			<p><?php echo esc_html( $text ); ?></p>
 		</div>
 		<footer>
-			<button class="gdpr-ok"><?php esc_html_e( 'OK', 'gdpr' ); ?></button>
+			<button class="gdpr-ok" data-callback="closeNotification"><?php esc_html_e( 'OK', 'gdpr' ); ?></button>
 		</footer>
 	</div>
 </div>


### PR DESCRIPTION
This is a PR to provide the suggested fix in this issue:

https://github.com/trewknowledge/GDPR/issues/232

This works for me, though I have only tested two different modals:

* Confirmation of delete
* Modal when the 'delete' link is already used - "request key expired"