### PR TITLE
Fix for success handler for gdpr-privacy-preferences-frm submission

### DIFF
--- a/src/js/public/gdpr-public.js
+++ b/src/js/public/gdpr-public.js
@@ -98,17 +98,16 @@
 
 		$(document).on('submit', '.gdpr-privacy-preferences-frm', function(e) {
 			e.preventDefault();
-			var that = $(this);
 			var formData = $(this).serialize();
 
 			$.post(
 				GDPR.ajaxurl,
 				formData,
-				function(response) {
-					if ( response.success ) {
+				function(response, textStatus, xhr) {
+					if ( 200 === xhr.status ) {                    
 						Cookies.set('gdpr[privacy_bar]', 1, { expires: 365 });
 						if ( GDPR.refresh ) {
-							window.location.reload();
+							window.location.reload(true);
 						} else {
               var scrollDistance = $('body').css('top');
 							$('.gdpr-overlay').fadeOut();


### PR DESCRIPTION
* Removes unused local variable
* Found `response.status` is undefined, so use `xhr.status` check instead - however may not be needed
* Force `window.location.reload` to load page from server, rather than local cache

It may be that the `200 === xhr.status` check is not required. This is the success handler function, so a successful outcome is assumed(?)

I haven't updated the `else` / `displayNotification` function, as I'm not sure what the expected contents of the `response.data...` object would be. Perhaps hardcoded with translated error strings?