### PR TITLE
Fix $gdpr_type typo

### DIFF
--- a/templates/privacy-preferences-modal.php
+++ b/templates/privacy-preferences-modal.php
@@ -84,7 +84,7 @@
 											<?php endif; ?>
 										</div>
 										<div class="gdpr-cookies">
-											<span><?php echo wp_kses( $type['description'], $args['allowed_html'] ); ?></span>
+											<span><?php echo wp_kses( $gdpr_type['description'], $args['allowed_html'] ); ?></span>
 										</div>
 									</div>
 								<?php endforeach; ?>


### PR DESCRIPTION
Solves PHP Notice: Undefined variable: type in /wp-content/plugins/gdpr/templates/privacy-preferences-modal.php on line 87

https://wordpress.org/support/topic/v-2-1-1-bug-php-notice-undefined-variable-type/